### PR TITLE
Potential fix for code scanning alert no. 8: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/combine-prs.yml
+++ b/.github/workflows/combine-prs.yml
@@ -1,3 +1,6 @@
+permissions:
+  contents: write
+  pull-requests: write
 name: 'Combine PRs'
 
 # Controls when the action will run - in this case triggered manually


### PR DESCRIPTION
Potential fix for [https://github.com/Hyperclaw79/ht.dev/security/code-scanning/8](https://github.com/Hyperclaw79/ht.dev/security/code-scanning/8)

To fix the issue, you should add a `permissions` block to the workflow, either at the workflow root (before `jobs:`) or under the `combine-prs` job. Given only a single job is present, setting it at the root will clarify the default. You must assign only the required privileges: the workflow reads repository contents and writes branches and pull requests, so these scopes need `contents: write` and `pull-requests: write`. Other permissions should remain unset to enforce least privilege. Add these lines directly below the `name:` field, before `on:`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
