### PR TITLE
Combined PR

### DIFF
--- a/svelteapp/package-lock.json
+++ b/svelteapp/package-lock.json
@@ -2448,9 +2448,9 @@
 			"license": "CC-BY-4.0"
 		},
 		"node_modules/canvg": {
-			"version": "3.0.10",
-			"resolved": "https://registry.npmjs.org/canvg/-/canvg-3.0.10.tgz",
-			"integrity": "sha512-qwR2FRNO9NlzTeKIPIKpnTY6fqwuYSequ8Ru8c0YkYU7U0oW+hLUvWadLvAu1Rl72OMNiFhoLu4f8eUjQ7l/+Q==",
+			"version": "3.0.11",
+			"resolved": "https://registry.npmjs.org/canvg/-/canvg-3.0.11.tgz",
+			"integrity": "sha512-5ON+q7jCTgMp9cjpu4Jo6XbvfYwSB2Ow3kzHKfIyJfaCAOHLbdKPQqGKgfED/R5B+3TFFfe8pegYA+b423SRyA==",
 			"optional": true,
 			"dependencies": {
 				"@babel/runtime": "^7.12.5",
@@ -9397,9 +9397,9 @@
 			"dev": true
 		},
 		"canvg": {
-			"version": "3.0.10",
-			"resolved": "https://registry.npmjs.org/canvg/-/canvg-3.0.10.tgz",
-			"integrity": "sha512-qwR2FRNO9NlzTeKIPIKpnTY6fqwuYSequ8Ru8c0YkYU7U0oW+hLUvWadLvAu1Rl72OMNiFhoLu4f8eUjQ7l/+Q==",
+			"version": "3.0.11",
+			"resolved": "https://registry.npmjs.org/canvg/-/canvg-3.0.11.tgz",
+			"integrity": "sha512-5ON+q7jCTgMp9cjpu4Jo6XbvfYwSB2Ow3kzHKfIyJfaCAOHLbdKPQqGKgfED/R5B+3TFFfe8pegYA+b423SRyA==",
 			"optional": true,
 			"requires": {
 				"@babel/runtime": "^7.12.5",

--- a/svelteapp/package-lock.json
+++ b/svelteapp/package-lock.json
@@ -7405,9 +7405,9 @@
 			}
 		},
 		"node_modules/undici": {
-			"version": "5.28.4",
-			"resolved": "https://registry.npmjs.org/undici/-/undici-5.28.4.tgz",
-			"integrity": "sha512-72RFADWFqKmUb2hmmvNODKL3p9hcB6Gt2DOQMis1SEBaV6a4MH8soBvzg+95CYhCKPFedut2JY9bMfrDl9D23g==",
+			"version": "5.29.0",
+			"resolved": "https://registry.npmjs.org/undici/-/undici-5.29.0.tgz",
+			"integrity": "sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==",
 			"dev": true,
 			"dependencies": {
 				"@fastify/busboy": "^2.0.0"
@@ -12595,9 +12595,9 @@
 			}
 		},
 		"undici": {
-			"version": "5.28.4",
-			"resolved": "https://registry.npmjs.org/undici/-/undici-5.28.4.tgz",
-			"integrity": "sha512-72RFADWFqKmUb2hmmvNODKL3p9hcB6Gt2DOQMis1SEBaV6a4MH8soBvzg+95CYhCKPFedut2JY9bMfrDl9D23g==",
+			"version": "5.29.0",
+			"resolved": "https://registry.npmjs.org/undici/-/undici-5.29.0.tgz",
+			"integrity": "sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==",
 			"dev": true,
 			"requires": {
 				"@fastify/busboy": "^2.0.0"

--- a/svelteapp/package-lock.json
+++ b/svelteapp/package-lock.json
@@ -484,12 +484,9 @@
 			}
 		},
 		"node_modules/@babel/runtime": {
-			"version": "7.24.8",
-			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.24.8.tgz",
-			"integrity": "sha512-5F7SDGs1T72ZczbRwbGO9lQi0NLjQxzl6i4lJxLxfW9U5UluCSyEJeniWvnhl3/euNiqQVbo8zruhsDfid0esA==",
-			"dependencies": {
-				"regenerator-runtime": "^0.14.0"
-			},
+			"version": "7.28.3",
+			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.3.tgz",
+			"integrity": "sha512-9uIQ10o0WGdpP6GDhXcdOJPJuDgFtIDtN/9+ArJQ2NAfAmiuhTQdzkaTGR33v43GYS2UrSA0eX2pPPHoFVvpxA==",
 			"engines": {
 				"node": ">=6.9.0"
 			}
@@ -6604,11 +6601,6 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/regenerator-runtime": {
-			"version": "0.14.1",
-			"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
-			"integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw=="
-		},
 		"node_modules/regexp.prototype.flags": {
 			"version": "1.4.3",
 			"dev": true,
@@ -8122,12 +8114,9 @@
 			}
 		},
 		"@babel/runtime": {
-			"version": "7.24.8",
-			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.24.8.tgz",
-			"integrity": "sha512-5F7SDGs1T72ZczbRwbGO9lQi0NLjQxzl6i4lJxLxfW9U5UluCSyEJeniWvnhl3/euNiqQVbo8zruhsDfid0esA==",
-			"requires": {
-				"regenerator-runtime": "^0.14.0"
-			}
+			"version": "7.28.3",
+			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.3.tgz",
+			"integrity": "sha512-9uIQ10o0WGdpP6GDhXcdOJPJuDgFtIDtN/9+ArJQ2NAfAmiuhTQdzkaTGR33v43GYS2UrSA0eX2pPPHoFVvpxA=="
 		},
 		"@babel/template": {
 			"version": "7.27.2",
@@ -12100,11 +12089,6 @@
 				"indent-string": "^4.0.0",
 				"strip-indent": "^3.0.0"
 			}
-		},
-		"regenerator-runtime": {
-			"version": "0.14.1",
-			"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
-			"integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw=="
 		},
 		"regexp.prototype.flags": {
 			"version": "1.4.3",


### PR DESCRIPTION
✅ This PR was created by the Combine PRs action by combining the following PRs:
#40 Bump @babel/runtime from 7.24.8 to 7.28.3 in /svelteapp
#39 Bump canvg from 3.0.10 to 3.0.11 in /svelteapp
#31 Bump undici from 5.28.4 to 5.29.0 in /svelteapp

⚠️ The following PRs were left out due to merge conflicts:
#38 Bump jspdf from 2.5.1 to 3.0.1 in /svelteapp
#26 Bump form-data from 4.0.0 to 4.0.4 in /svelteapp